### PR TITLE
Don't swallow touch events for form inputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ Change the css properties of the rendered touches.
 #### TouchEmulator.multiTouchOffset = 75
 The distance between the two touch points when entering the *multi-touch zone*.
 
-
+#### TouchEmulator.ignoreTags = [...]
+The names of HTML tags that shouldn't swallow mouse events (default: `['TEXTAREA', 'INPUT']`).

--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -319,7 +319,7 @@
     TouchEmulator.multiTouchOffset = 75;
 
     // tags that shouldn't swallow mouse events
-    TouchEmulator.ignoreTags = ['TEXTAREA', 'INPUT'];
+    TouchEmulator.ignoreTags = ['TEXTAREA', 'INPUT', 'SELECT'];
 
     /**
      * css template for the touch rendering

--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -125,8 +125,10 @@
      */
     function onMouse(touchType) {
         return function(ev) {
-            // prevent mouse events
-            preventMouseEvents(ev);
+            if (TouchEmulator.ignoreTags.indexOf(ev.target.tagName) < 0) {
+                // prevent mouse events
+                preventMouseEvents(ev);
+            }
 
             if (ev.which !== 1) {
                 return;
@@ -315,6 +317,9 @@
 
     // start distance when entering the multitouch mode
     TouchEmulator.multiTouchOffset = 75;
+
+    // tags that shouldn't swallow mouse events
+    TouchEmulator.ignoreTags = ['TEXTAREA', 'INPUT'];
 
     /**
      * css template for the touch rendering


### PR DESCRIPTION
TouchEmulator doesn't play nicely with form inputs (specifically text `<input>`s and `<textarea>`s): you can't click to focus them, and when they are focused, you can't move the cursor or change the selection.

I'm not sure if this is the best fix, but it seems to work in my very limited testing.
