### PR TITLE
Use capture phase and bump zIndex for the small touch feedback circle

### DIFF
--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -307,10 +307,10 @@
         window.addEventListener("mouseover", preventMouseEvents, true);
 
         // it uses itself!
-        window.addEventListener("touchstart", showTouches, false);
-        window.addEventListener("touchmove", showTouches, false);
-        window.addEventListener("touchend", showTouches, false);
-        window.addEventListener("touchcancel", showTouches, false);
+        window.addEventListener("touchstart", showTouches, true);
+        window.addEventListener("touchmove", showTouches, true);
+        window.addEventListener("touchend", showTouches, true);
+        window.addEventListener("touchcancel", showTouches, true);
     }
 
     // start distance when entering the multitouch mode
@@ -344,7 +344,8 @@
             userSelect: 'none',
             webkitTransform: transform,
             mozTransform: transform,
-            transform: transform
+            transform: transform,
+            zIndex: 100
         }
     };
 


### PR DESCRIPTION
I tested the script as bookmarklet on many mobile capable sites that use touch event, and since the small circle uses bubbling phase, it was being cancelled by some websites. By using capture phase, it works flawlessly, as I didn't find any website canceling the events during capture phase.

Other websites that use `zIndex` and `translate3D` are able to hide the small circle. By adding `zIndex:100` should help most cases.