### PR TITLE
More emulation gestures

### DIFF
--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -390,6 +390,14 @@
 
     var timer = null;
     function notifyChange(message) {
+        
+        if (!window.jQuery) {
+            
+            console.log(message);
+            return;
+            
+        }
+        
         if (!$('#touch-emulator-notify').length) {
             var el = $('<div id="touch-emulator-notify" style="display:none;"><span></span></div>');
             $('body').append(el);
@@ -453,11 +461,7 @@
             TouchEmulator.multiTouchType = types[selected];
             var message = types[selected];
 
-            if (window.jQuery) {
-                notifyChange(message);
-            } else {
-                alert(message);
-            }
+            notifyChange(message);
 
         }
 


### PR DESCRIPTION
Hi, I'm working with touch interfaces and found this library very useful while working without a touch device. So I decided to modify it to my custom needs:

I added emulated multitouch gesture types (vertical, horizontal, rotate). In vertical and horizontal you can switch to three fingers using shift+alt.
I added keybinding for switching the gesture type => t 
I added keybinding for increasing/decreasing the multiTouchOffset  => arrow up/arrow down
If jQuery is present you see a notification with the changed parameter, if not, a console.log call happens.

I thought other people would need this, therefore this pull request! :)