### PR TITLE
Rotation bug in documentation example

### DIFF
--- a/tests/manual/hammer.html
+++ b/tests/manual/hammer.html
@@ -153,7 +153,7 @@
     var initAngle = 0;
     function onRotate(ev) {
         if(ev.type == 'rotatestart') {
-            initAngle = transform.angle || 0;
+            initAngle = (transform.angle || 0) - ev.rotation;
         }
 
         el.className = '';


### PR DESCRIPTION
Steps to reproduce this bug:
1. Take mobile phone and open this example https://cdn.rawgit.com/hammerjs/hammer.js/master/tests/manual/visual.html
2. Put two fingers over each other vertically, rotation will have wrong initial angle.

In this PR this bug is fixed.
Here related bug in hammer.js documentation example: hammerjs/hammer.js#1215