### PR TITLE
docs: Fix simple typo, timout -> timeout

### DIFF
--- a/tests/web-platform-tests/resources/testharness.js
+++ b/tests/web-platform-tests/resources/testharness.js
@@ -779,7 +779,7 @@ policies and contribution forms [3].
             return;
         }
         this.phase = this.phases.STARTED;
-        //If we don't get a result before the harness times out that will be a test timout
+        //If we don't get a result before the harness times out that will be a test timeout
         this.set_status(this.TIMEOUT, "Test timed out");
 
         tests.started = true;


### PR DESCRIPTION
There is a small typo in tests/web-platform-tests/resources/testharness.js.

Should read `timeout` rather than `timout`.

