### PR TITLE
Emulating event bubble for DOMs inside web components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>Touch Emulator Manual</title>
+</head>
+
+<body>
+
+    <div>Touch Emulator Manual</div>
+
+    <br>
+    <br>
+
+    <div>Manual:</div>
+    <ul>
+        <li>
+            <a href="tests/manual/events.html">events</a>
+        </li>
+        <li>
+            <a href="tests/manual/googlemaps.html">googlemaps</a>
+        </li>
+        <li>
+            <a href="tests/manual/hammer.html">hammer</a>
+        </li>
+        <li>
+            <a href="tests/manual/img.html">img</a>
+        </li>
+        <li>
+            <a href="tests/manual/leaflet.html">leaflet</a>
+        </li>
+        <li>
+            <a href="tests/manual/modernizr.html">modernizr</a>
+        </li>
+    </ul>
+
+    <br>
+    <br>
+    <div>Touch Events:</div>
+    <ul>
+        <li>
+            <a href="tests/web-platform-tests/touch-events/create-touch-touchlist.html">create-touch-touchlist</a>
+        </li>
+        <li>
+            <a href="tests/web-platform-tests/touch-events/multi-touch-interactions-manual.html">multi-touch-interactions-manual</a>
+
+        </li>
+        <li>
+            <a href="tests/web-platform-tests/touch-events/multi-touch-interfaces-manual.html">multi-touch-interfaces-manual</a>
+        </li>
+        <li>
+            <a href="tests/web-platform-tests/touch-events/single-touch-manual.html">single-touch-manual</a>
+        </li>
+    </ul>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "scripts": {
+    "dev": "vite dev",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -25,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/hammerjs/touchemulator/issues"
   },
-  "homepage": "https://github.com/hammerjs/touchemulator"
+  "homepage": "https://github.com/hammerjs/touchemulator",
+  "devDependencies": {
+    "vite": "^3.2.4"
+  }
 }

--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -137,14 +137,30 @@
             // The EventTarget on which the touch point started when it was first placed on the surface,
             // even if the touch point has since moved outside the interactive area of that element.
             // also, when the target doesnt exist anymore, we update it
+
             if (ev.type == 'mousedown' || !eventTarget || (eventTarget && !eventTarget.dispatchEvent)) {
-                if(ev.composedPath() && ev.composedPath().length > 0){
-                    eventTarget = ev.composedPath()[0]
-                }else {
+                var composedPathList = ev.composedPath();
+                // Emulating event bubble from composedPath()[0] to ev.target for DOMs inside Web Components . 
+                if(composedPathList.length > 0){
+                    for(var i = 0; i < composedPathList.length; i=i+1){
+                        if(composedPathList[i] != ev.target){
+                            eventTarget = composedPathList[i];
+                            processTriggerForOneElement(ev, touchType)
+                        }else{
+                            eventTarget = null;
+                            break;
+                        }
+                    }
+                } else {
                     eventTarget = ev.target;
+                    processTriggerForOneElement(ev, touchType)
                 }
             }
 
+        }
+    }
+
+    function processTriggerForOneElement(ev, touchType){
             // shiftKey has been lost, so trigger a touchend
             if (isMultiTouch && !ev.shiftKey) {
                 triggerTouch('touchend', ev);
@@ -173,7 +189,6 @@
                 isMultiTouch = false;
                 eventTarget = null;
             }
-        }
     }
 
     /**

--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -143,8 +143,12 @@
                 var composedPathList = ev.composedPath();
                 // Emulating event bubble from composedPath()[0] to ev.target for DOMs inside Web Components . 
                 if(composedPathList.length > 0){
-                    if(eventTargetList.length === 0 || eventTargetList.indexOf(composedPathList[0]) !== -1){
-                        eventTargetList.push(composedPathList[0])
+                    for(var i = 0; i < composedPathList.length; i = i+1){
+                        if(composedPathList[i]!==ev.target && (eventTargetList.length === 0 || eventTargetList.indexOf(composedPathList[i]) === -1 )){
+                          eventTargetList.push(composedPathList[i])
+                        } else {
+                          break;
+                        }
                     }
             
                     for(var j = 0; j < eventTargetList.length; j = j+1){

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  server: {
+    host: '0.0.0.0',
+    port: 8080,
+  },
+});


### PR DESCRIPTION
Hi J. Tangelder,

Here is my implementation to emulate event bubbles for DOMs inside web components. My previous solution was too simple. Please take a review.

1. It triggers **touch** events from composedPath()[0] to ev.target.
2. Adds vite as static server. Adds index.html for test manual pages.
